### PR TITLE
Corrected file name of nyt_util.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Datasets are updated once a day if there is a change.
 
 #### NYT datasets
 
-The `nt_util.py` script scrapes the NYT Tracker website and forms the dataset for vaccines in various phases and stages of approval.
+The `nyt_util.py` script scrapes the NYT Tracker website and forms the dataset for vaccines in various phases and stages of approval.
 
 - **nyt_approved_vaccine.csv** - Contains the dataset for all the approved vaccines around the world.
 - Others are coming...


### PR DESCRIPTION
Hey,
Just noticed some small mistake in the file name - nt_util.py mentioned in the Readme. So just corrected it to nyt_util.py.